### PR TITLE
Move AWS certificate management verification entry here

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/dnsimple/dnsimple" {
+  version = "0.9.2"
+  hashes = [
+    "h1:m2KP0rLv3qwpAJ11btgC2cGhmwdanU4PDBlBOwIPRWw=",
+    "zh:0391e094b71dca09daca018bd799998f8cdc94c873181aa9ed47d26f83c8d9db",
+    "zh:23c1006bc6bbf08f637163b2dc6c60f2c6523f4ab13c0afc5b5dacd285cc6b6f",
+    "zh:269cb921be14dcfc3d6b32526195df20a2643c954eea80480b6cca93b3df7cb3",
+    "zh:2a7f8bbbb42bbd3ed1a2c90e5cce00533534cce2dc4183473bd7e676a686b05e",
+    "zh:4d4f898eae9fea81a253880d7023e52151ade69b3d79f04328eb876a2b66088c",
+    "zh:50ee37d235d4984171d18f68146a118ad4cc25c235723af5162907ff7a9d3657",
+    "zh:59ce037250a01199d31209dbde5a636a34d29936d035241cfb4804eb229d68cf",
+    "zh:61a75c35341e073651aa633566ac57f198ca3292b28f8594a4a503ff05d23af1",
+    "zh:786db966bc1a664814442a21d2d63e0cfc9e534e191c3432a5a7fbc312881667",
+    "zh:9fe9a56d0434de9e1925357a3b65b061cbb6239a4ba4e508398fff21e0c28cbe",
+    "zh:a311c12fb30aabeaadb94c0895d87cdc38de58adca63d68d24383b7064c3a69c",
+    "zh:cd30f7d338bf3f7f479e6b6185492c565cb5ef65516f4b793fee31399c099f0c",
+    "zh:e98f73c7db7514ea41df2571433a8970d4b1d742176d7e9a8a88b772e1738a00",
+  ]
+}

--- a/aws-certificate.tf
+++ b/aws-certificate.tf
@@ -1,0 +1,6 @@
+resource "dnsimple_zone_record" "battlemap-app-aws-cert-verification" {
+  zone_name = "battlemap.app"
+  name      = "_fe30a0d323ee174ac95c1f69c9d6c19c"
+  value     = "_e1e6e20629e47c7ecb7dc1b9ece9a074.nhqijqilxf.acm-validations.aws"
+  type      = "CNAME"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,14 @@
-resource "dnsimple_record" "root" {
-  domain = "battlemap.app"
-  name   = ""
-  type   = "ALIAS"
-  value  = local.netlify_hostname
+resource "dnsimple_zone_record" "root" {
+  zone_name = "battlemap.app"
+  name      = ""
+  type      = "ALIAS"
+  value     = local.netlify_hostname
 }
 
-resource "dnsimple_record" "www" {
-  domain = "battlemap.app"
-  name   = "www"
-  type   = "CNAME"
-  value  = local.netlify_hostname
+resource "dnsimple_zone_record" "www" {
+  zone_name = "battlemap.app"
+  name      = "www"
+  type      = "CNAME"
+  value     = local.netlify_hostname
 }
 


### PR DESCRIPTION
Because:

* I'm breaking up the personal-sites monorepo, and this entry belongs here with the rest of the Battlemap entries
* And I'm updating to use the newer version of the DNSimple provider

Solution:

* Use dnsimple_zone_record instead of deprecated dnsimple_record
* Add the AWS certificate verification DNS entry here
